### PR TITLE
Add verify function

### DIFF
--- a/BitmarkSDK/Account/AccountNumber.swift
+++ b/BitmarkSDK/Account/AccountNumber.swift
@@ -24,6 +24,23 @@ public extension AccountNumber {
     func validate() throws {
         return try Account.validateAccountNumber(accountNumber: self)
     }
+    
+    func verify(message: Data, signature: Data) -> Bool {
+        do {
+            let (network, _, pubkey) = try self.parseAndVerifyAccountNumber()
+            if network != globalConfig.network {
+                return false
+            }
+            
+            return try AuthKey.verify(message: message,
+                                      signature: signature,
+                                      publicKey: pubkey)
+        }
+        catch let e {
+            globalConfig.logger.log(level: .error, message: e.localizedDescription)
+            return false
+        }
+    }
 }
 
 internal extension AccountNumber {

--- a/BitmarkSDK/Account/Key/AuthKey.swift
+++ b/BitmarkSDK/Account/Key/AuthKey.swift
@@ -125,8 +125,14 @@ internal struct AuthKey: KeypairSignable {
         let keyPairData = keyPairString.hexDecodedData
         try self.init(fromKeyPair: keyPairData, network: network, type: type)
     }
-    
+}
+
+extension AuthKey {
     func sign(message: Data) throws -> Data {
         return try NaclSign.signDetached(message: message, secretKey: privateKey)
+    }
+    
+    static func verify(message:Data, signature: Data, publicKey: Data) throws -> Bool {
+        return try NaclSign.signDetachedVerify(message: message, sig: signature, publicKey: publicKey)
     }
 }

--- a/BitmarkSDK/Account/Key/AuthKey.swift
+++ b/BitmarkSDK/Account/Key/AuthKey.swift
@@ -132,7 +132,7 @@ extension AuthKey {
         return try NaclSign.signDetached(message: message, secretKey: privateKey)
     }
     
-    static func verify(message:Data, signature: Data, publicKey: Data) throws -> Bool {
+    static func verify(message: Data, signature: Data, publicKey: Data) throws -> Bool {
         return try NaclSign.signDetachedVerify(message: message, sig: signature, publicKey: publicKey)
     }
 }

--- a/BitmarkSDKTests/Account_Tests.swift
+++ b/BitmarkSDKTests/Account_Tests.swift
@@ -11,6 +11,12 @@ import XCTest
 
 class Account_Tests: XCTestCase {
     
+    override class func setUp() {
+        BitmarkSDK.initialize(config: SDKConfig(apiToken: "bmk-lljpzkhqdkzmblhg",
+                                                network: .testnet,
+                                                urlSession: URLSession.shared))
+    }
+    
     func testAccountCreate() {
         do {
             let a = try Account()
@@ -33,6 +39,27 @@ class Account_Tests: XCTestCase {
             
             let seed = try a.getSeed()
             XCTAssertEqual(seed, seedString)
+        }
+        catch {
+            XCTFail()
+        }
+    }
+    
+    func testSignAndVerify() {
+        do {
+            let defaultAccount = try Account()
+            let wrongNetworkAccount = try Account(network: .livenet)
+            
+            let message = "This is a sample message".data(using: .utf8)!
+            
+            let defaultSignature = try defaultAccount.sign(message: message)
+            let wrongNetworkSignature = try wrongNetworkAccount.sign(message: message)
+            
+            // Verify
+            XCTAssertTrue(defaultAccount.address.verify(message: message, signature: defaultSignature))
+            XCTAssertFalse(wrongNetworkAccount.address.verify(message: message, signature: wrongNetworkSignature))
+            XCTAssertFalse(defaultAccount.address.verify(message: message, signature: Data()))
+            XCTAssertFalse(defaultAccount.address.verify(message: Data(), signature: defaultSignature))
         }
         catch {
             XCTFail()


### PR DESCRIPTION
Provides `AccountNumber.verify(message: signature:)` as counterpart of `Account.sign(message:)