### PR TITLE
Add utility to calculate SHA3 from parts

### DIFF
--- a/BitmarkSDK/Asset/RegistrationParams.swift
+++ b/BitmarkSDK/Asset/RegistrationParams.swift
@@ -119,8 +119,8 @@ public struct RegistrationParams {
     }
     
     public mutating func setFingerprint(fromFileURL fileURL: String) throws {
-        let fileData = try Data(contentsOf: URL(fileURLWithPath: fileURL))
-        try setFingerprint(fromData: fileData)
+        let fingerprint = try FileUtil.computeFingerprint(url: URL(fileURLWithPath: fileURL))
+        try self.set(fingerPrint: fingerprint)
     }
 }
 

--- a/BitmarkSDK/Utils/FileUtil.swift
+++ b/BitmarkSDK/Utils/FileUtil.swift
@@ -20,4 +20,9 @@ public struct FileUtil {
         let sha3Data = data.sha3(length: 512)
         return "01" + sha3Data.hexEncodedString
     }
+    
+    public static func computeFingerprint(url: URL) throws -> String {
+        let sha3Data = try url.sha3(length: 512)
+        return "01" + sha3Data.hexEncodedString
+    }
 }

--- a/BitmarkSDK/Utils/SHA3.swift
+++ b/BitmarkSDK/Utils/SHA3.swift
@@ -34,10 +34,65 @@ struct SHA3Compute {
         
         return output
     }
+  
+    static func computeSHA3FromURL(fileURL: URL, length: Int) throws -> Data {
+        let byteLength = length / 8
+      
+        let blockSize = 1024
+        
+        guard let inputStream = InputStream(url: fileURL) else {
+          throw("Cannot read the file at " + fileURL.absoluteString)
+        }
+        
+        var ctx = sha3_ctx_t()
+        withUnsafeMutablePointer(to: &ctx) { (ctxPointer) -> Void in
+            return sha3_init(ctxPointer, Int32(byteLength))
+        }
+        
+        var inputBuffer = [UInt8](repeating: 0, count: blockSize)
+        inputStream.open()
+        defer {
+            inputStream.close()
+        }
+        
+        while true {
+            let length = inputStream.read(&inputBuffer, maxLength: blockSize)
+            if length == 0 {
+                // EOF
+                break
+            }
+            else if length < 0 {
+                throw("Cannot read the file at " + fileURL.absoluteString)
+            }
+            
+            let dataBlock = Data(bytes: inputBuffer, count: length)
+            
+            dataBlock.withUnsafeBytes { (dataPointer) -> Void in
+                withUnsafeMutablePointer(to: &ctx) { (ctxPointer) -> Void in
+                  return sha3_update(ctxPointer, dataPointer, dataBlock.count)
+                }
+            }
+        }
+      
+        var output = Data(count: byteLength)
+        output.withUnsafeMutableBytes { (outputPointer: UnsafeMutablePointer<UInt8>) -> Void in
+            withUnsafeMutablePointer(to: &ctx) { (ctxPointer) -> Void in
+                sha3_final(outputPointer, ctxPointer)
+            }
+        }
+        
+        return output
+    }
 }
 
 public extension Data {
-    public func sha3(length: Int) -> Data {
+    func sha3(length: Int) -> Data {
         return SHA3Compute.computeSHA3(data: self, length: length)
+    }
+}
+
+public extension URL {
+    func sha3(length: Int) throws -> Data {
+        return try SHA3Compute.computeSHA3FromURL(fileURL: self, length: length)
     }
 }


### PR DESCRIPTION
This will speed up SHA3 calculation by approximately 20 times.

```
hash: 00ca853ed36cc615569d63b5e3b10a4514af3b0d199f0eb140429912c7d79f784b509655a078c904360223ffa387d0bf21b42da66344531387afa0c0b9d3291c
fileURL.sha3(length: 512):: Time: 0.0010449886322021484

hash: 00ca853ed36cc615569d63b5e3b10a4514af3b0d199f0eb140429912c7d79f784b509655a078c904360223ffa387d0bf21b42da66344531387afa0c0b9d3291c
data.sha3(length: 512):: Time: 0.02195894718170166
```